### PR TITLE
Allow JS errors in phantomjs by default

### DIFF
--- a/tests/rspec/lib/config.rb
+++ b/tests/rspec/lib/config.rb
@@ -26,7 +26,7 @@ end
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app,
     debug: false,
-    js_errors: true, # Use true if you are really careful about your site
+    js_errors: false, # Use true if you are really careful about your site
     phantomjs_logger: '/dev/null',
     timeout: 60,
     :phantomjs_options => [


### PR DESCRIPTION
90% of the time, phantomjs tests fail initially due to javascript
errors. People seem not to care about js errors and warnings on their site.

This change gives us a better chance to update our customers sites
automatically, which should increase the quality of the service.
