### PR TITLE
Use HTTPS in composer.json repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,11 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "http://wpackagist.org"
+      "url": "https://wpackagist.org"
     },
     {
       "type": "composer",
-      "url": "http://languages.koodimonni.fi"
+      "url": "https://wp-languages.github.io"
     }
   ],
   "require": {


### PR DESCRIPTION
Composer will force HTTPS in all repositories in near future and your config will break if these are not changed.