### PR TITLE
Bugfix: make DB_PORT actually effective

### DIFF
--- a/htdocs/wp-config.php
+++ b/htdocs/wp-config.php
@@ -31,8 +31,8 @@ if (file_exists($root_dir . '/.env')) {
 define('DB_NAME', getenv('DB_NAME'));
 define('DB_USER', getenv('DB_USER'));
 define('DB_PASSWORD', getenv('DB_PASSWORD'));
-define('DB_HOST', getenv('DB_HOST') ? getenv('DB_HOST') : 'localhost' );
 define('DB_PORT', getenv('DB_PORT') ? getenv('DB_PORT') : 3306 );
+define('DB_HOST', getenv('DB_HOST') ? getenv('DB_HOST') .':'. DB_PORT : 'localhost:' . DB_PORT );
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
 $table_prefix = getenv('DB_PREFIX') ? getenv('DB_PREFIX') : 'wp_';


### PR DESCRIPTION
The DB_PORT constant is not read by WordPress anywhere, so it alone
didn't have any effect. Append it to the end of the DB_HOST to have effect.

This change is fully backwards compatible but it introduces the possibility to change the DB_PORT in the future.