### PR TITLE
Remove  WP Native Dashboard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
 
     "wpackagist-plugin/auto-post-thumbnail": "*",
     "wpackagist-plugin/google-analytics-dashboard-for-wp": "*",
-    "wpackagist-plugin/wp-native-dashboard": "*",
 
     "wpackagist-theme/twentyseventeen": "*"
   },


### PR DESCRIPTION
WordPress core supports per user language selection nowadays; this plugin doesn't have much use anymore. 

It's also "incompatible" with PHP 7+: 
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; wp_native_dashboard has a deprecated constructor in /data/wordpress/htdocs/wp-content/plugins/wp-native-dashboard/wp-native-dashboard.php on line 103