### PR TITLE
Add full path for gulp in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,9 @@ before_script:
 
   # Install packages for gulp
   - npm install
+  
   # Test gulp and compile assets
-  - gulp
+  - ./node_modules/.bin/gulp
 
   # Install gems for rspec tests
   - gem install bundler


### PR DESCRIPTION
I think Travis CI has changed their logic of how they append to `$PATH`.

This fixes `gulp not found` error.