### PR TITLE
Update dotenv to version 2.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     "johnpbloch/wordpress-core": "^4.7",
     "composer/installers": "v1.0.12",
     "koodimonni/composer-dropin-installer": ">=0.2.4",
-    "vlucas/phpdotenv": "1.0.9",
+    "vlucas/phpdotenv": "v2.4.0",
 
     "koodimonni-language/fi": "*",
     "koodimonni-language/sv_SE": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -799,16 +799,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v1.0.9",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "56c252d48dce336da97926591aed71805203815b"
+                "reference": "3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/56c252d48dce336da97926591aed71805203815b",
-                "reference": "56c252d48dce336da97926591aed71805203815b",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c",
+                "reference": "3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c",
                 "shasum": ""
             },
             "require": {

--- a/htdocs/wp-config.php
+++ b/htdocs/wp-config.php
@@ -19,8 +19,8 @@ $webroot_dir = $root_dir . '/htdocs';
  * .env file is also heavily used in development
  */
 if (file_exists($root_dir . '/.env')) {
-  Dotenv::makeMutable();
-  Dotenv::load($root_dir);
+  $dotenv = new Dotenv\Dotenv($root_dir);
+  $dotenv->overload();
 }
 
 


### PR DESCRIPTION
Mutable env files are loaded with `Dotenv->overload()`.

* I faced some issues with dotenv 1.x with one plugin and I'm currently running something like this
* Not tested, maybe some of core contributors could test this
* composer.lock updated by hand, maybe you want to update it?

Fixes #36 