### PR TITLE
Use .test TLD for development purposes?

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,8 +132,8 @@ Vagrant.configure('2') do |config|
         # Seravo customers are asked if they want to pull the production database here
 
         # Install WordPress with defaults first
-        run_remote("wp core install --url=https://#{site_config['name']}.local --title=#{site_config['name'].capitalize}\
-         --admin_email=vagrant@#{site_config['name']}.local --admin_user=vagrant --admin_password=vagrant")
+        run_remote("wp core install --url=https://#{site_config['name']}.test --title=#{site_config['name'].capitalize}\
+         --admin_email=vagrant@#{site_config['name']}.test --admin_user=vagrant --admin_password=vagrant")
         run_remote("wp-pull-production-db")
       elsif File.exists?(File.join(DIR,'.vagrant','shutdown-dump.sql'))
         # Return the state where we last left if WordPress isn't currently installed
@@ -143,8 +143,8 @@ Vagrant.configure('2') do |config|
         run_remote("wp db import /data/wordpress/vagrant-base.sql")
       else
         # If nothing else was specified just install basic WordPress
-        run_remote("wp core install --url=https://#{site_config['name']}.local --title=#{site_config['name'].capitalize}\
-         --admin_email=vagrant@#{site_config['name']}.local --admin_user=vagrant --admin_password=vagrant")
+        run_remote("wp core install --url=https://#{site_config['name']}.test --title=#{site_config['name'].capitalize}\
+         --admin_email=vagrant@#{site_config['name']}.test --admin_user=vagrant --admin_password=vagrant")
         notice "Installed default WordPress with user:vagrant password:vagrant"
       end
 
@@ -203,7 +203,7 @@ Vagrant.configure('2') do |config|
 
       puts "\n"
       notice "Documentation available at https://seravo.com/docs/"
-      notice "Visit your site: https://#{site_config['name']}.local"
+      notice "Visit your site: https://#{site_config['name']}.test"
     end
 
     config.trigger.before :halt do
@@ -282,13 +282,13 @@ def get_domains(config)
   end
 
   # The main domain
-  domains << config['name']+".local"
+  domains << config['name']+".test"
 
   # Add domain names for included applications for easier usage
   subdomains = %w( www webgrind adminer mailcatcher browsersync info )
 
   subdomains.each do |domain|
-    domains << "#{domain}.#{config['name']}.local"
+    domains << "#{domain}.#{config['name']}.test"
   end
 
   domains.uniq #remove duplicates

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -10,6 +10,6 @@ name: wordpress
 development:
   # Domains are automatically mapped to Vagrant with /etc/hosts modifications
   domains:
-    - wordpress.local
+    - wordpress.test
   # If you want to use zeroconf (.local domains) in your network you can use this.
   #avahi: true


### PR DESCRIPTION
It seems that OS X in conjunction with Bonjour and IPv6 DNS resolving has some problems regarding .local TLD. Especially Browsersync proxying, but also using https://wordpress.local, reloading pages (or stylesheets) brings up a lot of 502 Bad Gateway errors on requests.

As per https://tools.ietf.org/html/rfc2606, there are some TLDs reserved for private networking matters, and since apparently at least Chrome seems to resolve .localhost TLDs to 127.0.0.1 automatically, .test would be a good candidate for local development purposes.

The selection of TLD may require some additional reviewing, along with possibly checking out whether the ".local" should be replaced with ".test" (or the selected TLD) elsewhere in the project.

This probably will break some avahi/autoconf functionality, if that is a crucial thing, but at least I would rather have a development environment without extraneous 502 errors than the avahi thing :)

Note: This is basically just sed -i 's/\\.local/\\.test/g' Vagrantfile and then a manual change to config(-sample).yml.