### PR TITLE
Vagrant CPU fix for OS X: use only physical CPU cores (Closes #98)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -218,7 +218,7 @@ Vagrant.configure('2') do |config|
   config.vm.provider 'virtualbox' do |vb|
     # Give VM access to all cpu cores on the host
     cpus = case RbConfig::CONFIG['host_os']
-      when /darwin/ then `sysctl -n hw.ncpu`.to_i
+      when /darwin/ then `sysctl -n hw.physicalcpu`.to_i
       when /linux/ then `nproc`.to_i
       else 2
     end


### PR DESCRIPTION
See #98 for a discussion about this change. I tested with the new `seravo/wordpress-beta` Vagrant image that has Avahi enabled, and additionally also disabled XDebug. I believe this is the fastest we have ever had Vagrant work on OS X:
*Before this change*
```
 Leo@Leos-MacBook-Pro$ for i in {1..50}; do curl -H Pragma:no-cache -w "%{time_total}\n" -o /dev/null -m10 -s https://wp-palvelu.local/ominaisuudet --insecure; done | awk '{ sum+=$1} END {print sum/50}'
1.90317
 Leo@Leos-MacBook-Pro$ for i in {1..50}; do curl -H Pragma:no-cache -w "%{time_total}\n" -o /dev/null -m10 -s https://wp-palvelu.local/tilaa --insecure; done | awk '{ sum+=$1} END {print sum/50}'
1.8698
```
*After this change*
```
Leo@Leos-MacBook-Pro$ for i in {1..50}; do curl -H Pragma:no-cache -w "%{time_total}\n" -o /dev/null -m10 -s https://wp-palvelu.local/ominaisuudet --insecure; done | awk '{ sum+=$1} END {print sum/50}'
1.20439
Leo@Leos-MacBook-Pro$ for i in {1..50}; do curl -H Pragma:no-cache -w "%{time_total}\n" -o /dev/null -m10 -s https://wp-palvelu.local/tilaa --insecure; done | awk '{ sum+=$1} END {print sum/50}'
1.24668
```
I also found some additional information about this phenomenon in http://www.mihaimatei.com/virtualbox-performance-issues-multiple-cpu-cores/.