### PR TITLE
Replace vagrant triggers plugin with core triggers (Closes: #88)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,8 +41,36 @@ else
 end
 
 # Multiple public_network mappings need at least 1.7.4
-# Custom triggers stop working in 2.1.0 so that is max for now
-Vagrant.require_version '>= 1.7.4', '< 2.1.0'
+Vagrant.require_version '>= 1.7.4'
+
+# Try to use the vagrant-triggers plugin when using a vagrant version below 2.1.0 or
+# if the user has self chosen to do so by setting the VAGRANT_USE_VAGRANT_TRIGGERS
+# environment variable.
+use_triggers_plugin = false
+triggers_plugin_installed = Vagrant.has_plugin? 'vagrant-triggers'
+if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('2.1.0')
+  # Vagrant core triggers are available, but the user can also opt-in to
+  # use the plugin if it is installed
+  if triggers_plugin_installed
+    use_triggers_plugin = true
+    if ENV['VAGRANT_USE_VAGRANT_TRIGGERS'].nil?
+      # Exit here because starting Vagrant will not work if VAGRANT_USE_VAGRANT_TRIGGERS is
+      # not defined but at the same time the vagrant-triggers plugin is installed.
+      STDERR.puts 'ERROR: can not use the Vagrant trigger functionality'
+      STDERR.puts 'Please uninstall the vagrant-triggers plugin to fix the problem:'
+      STDERR.puts '$ vagrant plugin uninstall vagrant-triggers'
+      exit 1
+    end
+  end
+else
+  # No choice but to use the plugin, but we need to ensure that it is installed
+  use_triggers_plugin = true
+  if !triggers_plugin_installed
+    STDERR.puts 'ERROR: can not use the Vagrant trigger functionality'
+    STDERR.puts 'Please update Vagrant to version 2.1.0 or newer to fix the problem'
+    exit 1
+  end
+end
 
 Vagrant.configure('2') do |config|
 
@@ -108,111 +136,10 @@ Vagrant.configure('2') do |config|
     config.vm.provision :shell, :inline => "echo '#{id_rsa_ssh_key_pub }' >> /home/vagrant/.ssh/authorized_keys && chmod 600 /home/vagrant/.ssh/authorized_keys"
   end
 
-  # Some useful triggers for better workflow
-  if Vagrant.has_plugin? 'vagrant-triggers'
-    config.trigger.after :up do
-
-      #Run all system commands inside project root
-      Dir.chdir(DIR)
-
-      # Install packages with Composer
-      # run it locally if possible
-      if find_executable 'composer' and system "composer validate &>/dev/null"
-        system "composer install"
-      else # run in vagrant
-        run_remote "composer install --working-dir=/data/wordpress"
-      end
-
-      # Sync plugin files from production is so configured to do
-      if site_config['production'] != nil && site_config['production']['ssh_port'] != nil and site_config['development']['pull_production_plugins'] == 'always'
-        run_remote("wp-pull-production-plugins")
-      end
-
-      # Sync theme files from production is so configured to do
-      if site_config['production'] != nil && site_config['production']['ssh_port'] != nil and site_config['development']['pull_production_themes'] == 'always'
-        run_remote("wp-pull-production-themes")
-      end
-
-      # Database imports
-      if site_config['production'] != nil && site_config['production']['ssh_port'] != nil && site_config['development']['pull_production_db'] != 'never' && (site_config['development']['pull_production_db'] == 'always' or confirm("Pull database from production?", false))
-        # Seravo customers are asked if they want to pull the production database here
-
-        # Install WordPress with defaults first so the database is not empty. Will automatically skip if WP was already installed.
-        run_remote("wp core install --url=https://#{site_config['name']}.local --title=#{site_config['name'].capitalize}\
-         --admin_email=vagrant@#{site_config['name']}.local --admin_user=vagrant --admin_password=vagrant")
-        # Pull production DB
-        run_remote("wp-pull-production-db")
-      elsif File.exists?(File.join(DIR,'.vagrant','shutdown-dump.sql'))
-        # Return the state where we last left if WordPress isn't currently installed
-        # First part in the command prevents overriding existing database
-        run_remote("wp core is-installed --quiet &>/dev/null || wp-vagrant-import-db")
-      elsif File.exists?(File.join(DIR,'vagrant-base.sql'))
-        run_remote("wp db import /data/wordpress/vagrant-base.sql")
-      else
-        # If nothing else was specified just install basic WordPress
-        run_remote("wp core install --url=https://#{site_config['name']}.local --title=#{site_config['name'].capitalize}\
-         --admin_email=vagrant@#{site_config['name']}.local --admin_user=vagrant --admin_password=vagrant")
-        notice "Installed default WordPress with user:vagrant password:vagrant"
-      end
-
-      # Init git if it doesn't exist
-      if not File.exists?( File.join(DIR,".git") ) and confirm "There's no git repository. Should we create one?"
-        system "git init ."
-      end
-
-      # Don't activate git hooks, just notify them
-      if File.exists?( File.join(DIR,'.git', 'hooks', 'pre-commit') )
-        puts "If you want to use a git pre-commit hook please run 'wp-activate-git-hooks' inside the Vagrant box."
-      end
-
-      case RbConfig::CONFIG['host_os']
-      when /darwin/
-        # Do OS X specific things
-
-        # Trust the self-signed cert in keychain
-        unless File.exists?(File.join(ssl_cert_path,'trust.lock'))
-          if File.exists?(File.join(ssl_cert_path,'development.crt')) and confirm "Trust the generated ssl-certificate in OS-X keychain?"
-            system "sudo security add-trusted-cert -d -r trustRoot -k '/Library/Keychains/System.keychain' '#{ssl_cert_path}/development.crt'"
-            # Write lock file so we can remove it too
-            touch_file File.join(ssl_cert_path,'trust.lock')
-          end
-        end
-      when /linux/
-        # Do linux specific things
-      end
-
-      # Attempt to use the asset proxy for production url defined in config.yml
-      run_remote "wp-use-asset-proxy"
-
-      # Restart nginx because the file system might not have been ready when the certificate was created
-      run_remote "wp-restart-nginx"
-
-      # Run 'vagrant up' customizer script if it exists
-      if File.exist?(File.join(DIR, 'vagrant-up-customizer.sh'))
-        notice 'Found vagrant-up-customizer.sh and running it ...'
-        Dir.chdir(DIR)
-        system 'sh ./vagrant-up-customizer.sh'
-      end
-
-      puts "\n"
-      notice "Documentation available at https://seravo.com/docs/"
-      notice "Visit your site: https://#{site_config['name']}.local"
-    end
-
-    config.trigger.before :halt do
-      # dump database when closing vagrant
-      dump_wordpress_database
-    end
-
-    config.trigger.before :destroy do
-      # dump database when destroying vagrant
-      dump_wordpress_database
-    end
-
+  if use_triggers_plugin
+    vagrant_triggers_plugin_triggers(config, site_config)
   else
-    puts 'vagrant-triggers missing, please install the plugin:'
-    puts 'vagrant plugin install vagrant-triggers'
-    exit 1
+    vagrant_triggers(config, site_config)
   end
 
   config.vm.provider 'virtualbox' do |vb|
@@ -232,6 +159,242 @@ Vagrant.configure('2') do |config|
     vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
   end
 
+end
+
+##
+# Run Vagrant triggers using the vagrant core trigger feature
+##
+def vagrant_triggers(vagrant_config, site_config)
+  vagrant_config.trigger.after :up do |trigger|
+    trigger.ruby do |env, machine|
+      #Run all system commands inside project root
+      Dir.chdir(DIR)
+
+      # Install packages with Composer
+      # run it locally if possible
+      if find_executable 'composer' and system "composer validate &>/dev/null"
+        system "composer install"
+      else # run in vagrant
+        run_command("composer install --working-dir=/data/wordpress", machine)
+      end
+
+      # Sync plugin files from production is so configured to do
+      if site_config['production'] != nil && site_config['production']['ssh_port'] != nil and site_config['development']['pull_production_plugins'] == 'always'
+        run_command("wp-pull-production-plugins", machine)
+      end
+
+      # Sync theme files from production is so configured to do
+      if site_config['production'] != nil && site_config['production']['ssh_port'] != nil and site_config['development']['pull_production_themes'] == 'always'
+        run_command("wp-pull-production-themes", machine)
+      end
+
+      # Database imports
+      if site_config['production'] != nil && site_config['production']['ssh_port'] != nil && site_config['development']['pull_production_db'] != 'never' && (site_config['development']['pull_production_db'] == 'always' or confirm("Pull database from production?", false))
+        # Seravo customers are asked if they want to pull the production database here
+
+        # Install WordPress with defaults first so the database is not empty. Will automatically skip if WP was already installed.
+        run_command("wp core install --url=https://#{site_config['name']}.local --title=#{site_config['name'].capitalize}\
+          --admin_email=vagrant@#{site_config['name']}.local --admin_user=vagrant --admin_password=vagrant", machine)
+        # Pull production DB
+        run_command("wp-pull-production-db", machine)
+      elsif File.exists?(File.join(DIR,'.vagrant','shutdown-dump.sql'))
+        # Return the state where we last left if WordPress isn't currently installed
+        # First part in the command prevents overriding existing database
+        run_command("wp core is-installed --quiet &>/dev/null || wp-vagrant-import-db", machine)
+      elsif File.exists?(File.join(DIR,'vagrant-base.sql'))
+        run_command("wp db import /data/wordpress/vagrant-base.sql", machine)
+      else
+        # If nothing else was specified just install basic WordPress
+        run_command("wp core install --url=https://#{site_config['name']}.local --title=#{site_config['name'].capitalize}\
+          --admin_email=vagrant@#{site_config['name']}.local --admin_user=vagrant --admin_password=vagrant", machine)
+        notice "Installed default WordPress with user:vagrant password:vagrant"
+      end
+
+      # Init git if it doesn't exist
+      if not File.exists?( File.join(DIR,".git") ) and confirm "There's no git repository. Should we create one?"
+        system "git init ."
+      end
+
+      # Don't activate git hooks, just notify them
+      if File.exists?( File.join(DIR,'.git', 'hooks', 'pre-commit') )
+        puts "If you want to use a git pre-commit hook please run 'wp-activate-git-hooks' inside the Vagrant box."
+      end
+
+      case RbConfig::CONFIG['host_os']
+      when /darwin/
+        # Do OS X specific things
+
+        # Trust the self-signed cert in keychain
+        ssl_cert_path = File.join(DIR,'.vagrant','ssl')
+        unless File.exists?(File.join(ssl_cert_path,'trust.lock'))
+          if File.exists?(File.join(ssl_cert_path,'development.crt')) and confirm "Trust the generated ssl-certificate in OS-X keychain?"
+            system "sudo security add-trusted-cert -d -r trustRoot -k '/Library/Keychains/System.keychain' '#{ssl_cert_path}/development.crt'"
+            # Write lock file so we can remove it too
+            touch_file File.join(ssl_cert_path,'trust.lock')
+          end
+        end
+      when /linux/
+        # Do linux specific things
+      end
+
+      # Attempt to use the asset proxy for production url defined in config.yml
+      run_command("wp-use-asset-proxy", machine)
+
+      # Restart nginx because the file system might not have been ready when the certificate was created
+      run_command("wp-restart-nginx", machine)
+
+      # Run 'vagrant up' customizer script if it exists
+      if File.exist?(File.join(DIR, 'vagrant-up-customizer.sh'))
+        notice 'Found vagrant-up-customizer.sh and running it ...'
+        Dir.chdir(DIR)
+        system 'sh ./vagrant-up-customizer.sh'
+      end
+
+      puts "\n"
+      notice "Documentation available at https://seravo.com/docs/"
+      notice "Visit your site: https://#{site_config['name']}.local"
+    end
+  end
+
+  vagrant_config.trigger.before [:halt, :destroy] do |trigger|
+    trigger.info = "Dump WordPress database into: .vagrant/shutdown-dump.sql"
+    trigger.ruby do |env, machine|
+      # dump database when closing vagrant
+      if vagrant_running?
+        begin
+          run_command("wp-vagrant-dump-db", machine)
+        rescue => e
+          notice "Couldn't dump database. Skipping..."
+        end
+      end
+    end
+  end
+end
+
+##
+# Helper function to run a command in a vagrant machine by providing the command
+# and a Vagrant::Machine object as parameters. Heavily influenced by
+# https://github.com/emyl/vagrant-triggers/blob/master/lib/vagrant-triggers/dsl.rb
+##
+def run_command(cmd, machine)
+  exit_code = 1
+  good_exit_codes = (0..255).to_a
+  begin
+    exit_code = machine.communicate.sudo(cmd, :elevated => true, :good_exit => good_exit_codes) do |channel, data|
+      machine.ui.send(:info, data)
+    end
+  rescue => e
+    machine.ui.send(:error, e.message)
+  end
+  if !good_exit_codes.include? exit_code
+    exit exit_code
+  end
+  return exit_code
+end
+
+##
+# Run Vagrant triggers in a vagrant-triggers plugin compatible format
+##
+def vagrant_triggers_plugin_triggers(vagrant_config, site_config)
+  # Some useful triggers for better workflow
+  vagrant_config.trigger.after :up do
+    #Run all system commands inside project root
+    Dir.chdir(DIR)
+
+    # Install packages with Composer
+    # run it locally if possible
+    if find_executable 'composer' and system "composer validate &>/dev/null"
+      system "composer install"
+    else # run in vagrant
+      run_remote "composer install --working-dir=/data/wordpress"
+    end
+
+    # Sync plugin files from production is so configured to do
+    if site_config['production'] != nil && site_config['production']['ssh_port'] != nil and site_config['development']['pull_production_plugins'] == 'always'
+      run_remote "wp-pull-production-plugins"
+    end
+
+    # Sync theme files from production is so configured to do
+    if site_config['production'] != nil && site_config['production']['ssh_port'] != nil and site_config['development']['pull_production_themes'] == 'always'
+      run_remote "wp-pull-production-themes"
+    end
+
+    # Database imports
+    if site_config['production'] != nil && site_config['production']['ssh_port'] != nil && site_config['development']['pull_production_db'] != 'never' && (site_config['development']['pull_production_db'] == 'always' or confirm("Pull database from production?", false))
+      # Seravo customers are asked if they want to pull the production database here
+
+      # Install WordPress with defaults first so the database is not empty. Will automatically skip if WP was already installed.
+      run_remote("wp core install --url=https://#{site_config['name']}.local --title=#{site_config['name'].capitalize}\
+        --admin_email=vagrant@#{site_config['name']}.local --admin_user=vagrant --admin_password=vagrant")
+      # Pull production DB
+      run_remote "wp-pull-production-db"
+    elsif File.exists?(File.join(DIR,'.vagrant','shutdown-dump.sql'))
+      # Return the state where we last left if WordPress isn't currently installed
+      # First part in the command prevents overriding existing database
+      run_remote "wp core is-installed --quiet &>/dev/null || wp-vagrant-import-db"
+    elsif File.exists?(File.join(DIR,'vagrant-base.sql'))
+      run_remote "wp db import /data/wordpress/vagrant-base.sql"
+    else
+      # If nothing else was specified just install basic WordPress
+      run_remote("wp core install --url=https://#{site_config['name']}.local --title=#{site_config['name'].capitalize}\
+        --admin_email=vagrant@#{site_config['name']}.local --admin_user=vagrant --admin_password=vagrant")
+      notice "Installed default WordPress with user:vagrant password:vagrant"
+    end
+
+    # Init git if it doesn't exist
+    if not File.exists?( File.join(DIR,".git") ) and confirm "There's no git repository. Should we create one?"
+      system "git init ."
+    end
+
+    # Don't activate git hooks, just notify them
+    if File.exists?( File.join(DIR,'.git', 'hooks', 'pre-commit') )
+      puts "If you want to use a git pre-commit hook please run 'wp-activate-git-hooks' inside the Vagrant box."
+    end
+
+    case RbConfig::CONFIG['host_os']
+    when /darwin/
+      # Do OS X specific things
+
+      # Trust the self-signed cert in keychain
+      ssl_cert_path = File.join(DIR,'.vagrant','ssl')
+      unless File.exists?(File.join(ssl_cert_path,'trust.lock'))
+        if File.exists?(File.join(ssl_cert_path,'development.crt')) and confirm "Trust the generated ssl-certificate in OS-X keychain?"
+          system "sudo security add-trusted-cert -d -r trustRoot -k '/Library/Keychains/System.keychain' '#{ssl_cert_path}/development.crt'"
+          # Write lock file so we can remove it too
+          touch_file File.join(ssl_cert_path,'trust.lock')
+        end
+      end
+    when /linux/
+      # Do linux specific things
+    end
+
+    # Attempt to use the asset proxy for production url defined in config.yml
+    run_remote "wp-use-asset-proxy"
+
+    # Restart nginx because the file system might not have been ready when the certificate was created
+    run_remote "wp-restart-nginx"
+
+    # Run 'vagrant up' customizer script if it exists
+    if File.exist?(File.join(DIR, 'vagrant-up-customizer.sh'))
+      notice 'Found vagrant-up-customizer.sh and running it ...'
+      Dir.chdir(DIR)
+      system 'sh ./vagrant-up-customizer.sh'
+    end
+
+    puts "\n"
+    notice "Documentation available at https://seravo.com/docs/"
+    notice "Visit your site: https://#{site_config['name']}.local"
+  end
+
+  vagrant_config.trigger.before :halt do
+    # dump database when closing vagrant
+    dump_wordpress_database
+  end
+
+  vagrant_config.trigger.before :destroy do
+    # dump database when closing vagrant
+    dump_wordpress_database
+  end
 end
 
 ##
@@ -299,7 +462,8 @@ def confirm(question,default=true)
 
   confirm = nil
   until ["Y","N","YES","NO",""].include?(confirm)
-    confirm = ask "#{question} (#{default}): "
+    print "#{question} (#{default}): "
+    confirm = STDIN.gets.chomp
 
     if (confirm.nil? or confirm.empty?)
       confirm = default


### PR DESCRIPTION
The idea is to not force developers to immediately update their Vagrant
versions, and provide a smooth backwards compatibility to the usage of the
vagrant-triggers plugin. The Vagrantfile now contains definitions for both
Vagrant core and vagrant-triggers plugin triggers, and the decision between
the two is made with the following logic:
- if the user uses a Vagrant version with support for core triggers and
vagrant-triggers is not installed, then use core triggers directly
- if the user uses a Vagrant version with support for core triggers but still
has the vagrant-triggers plugin installed, he/she can either uninstall the
plugin or define VAGRANT_USE_VAGRANT_TRIGGERS as an environment variable so
that Vagrant internally knows to use the vagrant-triggers plugin syntax
- if an older version of Vagrant is used, then the vagrant-triggers plugin
is required to be installed

After this we can advise our customers to start updating their Virtualbox
and Vagrant versions (and uninstall vagrant-triggers). After that, we can
proceed to drop the backwards-compatibility support for the vagrant-triggers
plugin somewhere in the future.