### PR TITLE
Use stdin data provided by Git to list changes in post-receive hook

### DIFF
--- a/scripts/git-hooks/post-receive
+++ b/scripts/git-hooks/post-receive
@@ -21,8 +21,15 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"/../..
 # Hack: Somehow this script won't understand that git is in current directory
 GIT_DIR="$(pwd)/.git"
 
-# Loop through all changed files
-changed_files=$(git diff --name-only --diff-filter=ACM HEAD HEAD^)
+# Loop through all changed files, only take pushes to master into consideration.
+# If you use some other branch for production, change "refs/heads/master" to
+# something else like "refs/heads/yourbranch".
+changed_files=""
+while read oldrev newrev refname; do
+  if [ "$refname" = "refs/heads/master" ]; then
+    changed_files=$(git diff-tree --name-only -r $oldrev $newrev)
+  fi
+done
 
 # Check files which have triggers
 COMPOSER_CHANGED=false


### PR DESCRIPTION
Identical to the good solution provided in #103, which was unfortunately
left unnoticed for some time.

Tested to list correct files in most typical git usage scenarios. Currently
this does not do anything when not pushing to the master branch, because
that is probably not intended behaviour. If the user wishes, the git hook
can be modified to use a different branch name as described in the inline
comments in the code.

Closes: #103
Closes: #117