### PR TITLE
Run Travis CI tests inside our CI image via a .seravo-ci test script

### DIFF
--- a/.seravo-ci
+++ b/.seravo-ci
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This is an example test script that will be run by the
+# entrypoint of Docker containers created from the seravo/wordpress:ci image.
+# The default Travis CI configuration file .travis.yml in this repository starts
+# a new container from the seravo/wordpress:ci image, and exits with the exit
+# code from this script.
+#
+# Although this example CI test script file is written as a bash script, at will,
+# it can as well be transformed to use interpreters of other scripting languages
+# that are installed inside the container, like Python, for instance.
+
+# Fail immediately on errors
+set -e
+
+## EXAMPLE: Import a default database dump to resemble the database contents
+## of the production site.
+# wp-db-load --yes "${PROJECT_DIR}"/vagrant-base.sql
+
+# Prefer to install plugins via Composer ("composer install" is automatically
+# run during container start), but here you can run e.g. WP-CLI commands to
+# install themes/plugins.
+
+## EXAMPLE: Run unit tests and static code analysis with e.g. PHPUnit and
+## PHPCS, both of which are pre-installed inside the seravo/wordpress:ci
+## image.
+# phpunit --verbose
+# phpcs --standard="${PROJECT_DIR}"/phpcs.xml -s -d memory_limit=-1 "${PROJECT_DIR}"/htdocs/wp-content
+
+# WP core might need an explicit database update if above scripts installed a
+# WP version newer than what was used for the vagrant-base.sql.
+wp core update-db
+
+# Run acceptance tests
+/data/wordpress/scripts/run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,55 +1,36 @@
 os: linux
 dist: bionic
-language: php
+language: generic
 
-services: mysql
-
-php:
-  - 7.3
-  - 7.4
-  - 8.0
-  - nightly
+services:
+  - docker
 
 env:
-  - WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test DB_USER=root DB_PASSWORD='' DB_NAME=test
+  global:
+    - DOCKER_CONTAINER=wordpress
 
-jobs:
-  allow_failures:
-    - php: 8.0
-    - php: nightly
+# Store Composer cache so it runs faster
+cache:
+  directories:
+    - $HOME/.composer/cache
 
-before_script:
-  # Downgrade Composer to latest 1.x series
-  - composer self-update 1.10.16
-  # Install composer packages before trying to activate themes or plugins
-  - composer install
-  # Create database
-  - mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASSWORD"
-  # Install router so that we don't need nginx/php-fpm
-  - curl -s https://raw.githubusercontent.com/Seravo/wordpress-test-template/master/lib/router.php > htdocs/router.php
-  # Start php server on background
-  - cd htdocs && php -S 0.0.0.0:12000 router.php &
-  # Install WordPress with wp-cli
-  - curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-  - php wp-cli.phar core install --url=$WP_TEST_URL --title='Test' --admin_user=$WP_TEST_USER --admin_password=$WP_TEST_USER_PASS --admin_email="$WP_TEST_USER@wordpress.dev" --path=htdocs/wordpress
-
-  # Activate all plugins
-  - php wp-cli.phar plugin activate --all --path=htdocs/wordpress
-
-  # test webserver
-  - curl -i http://localhost:12000
-
-  # Install packages for gulp
-  - npm install
-
-  # Test gulp and compile assets
-  - ./node_modules/.bin/gulp
+# Do installation in separate steps as Travis-CI is sometimes smart enough to automatically
+# re-run the install step if it failed
+install:
+  - curl -Os https://raw.githubusercontent.com/Seravo/gnitpick/master/gnitpick.py
 
 script:
-  # Remove one file to avoid false positive __autoload() detection by php -l later on
-  - rm htdocs/wordpress/wp-includes/spl-autoload-compat.php
-  # Remove a PHP 8 -only compatible file to avoid failures on older PHP syntax check runs
-  - rm vendor/symfony/polyfill-mbstring/bootstrap80.php
-  # Syntax check all php files and fail for any error text in STDERR
-  - '! find . -type f -name "*.php" -exec php -d error_reporting=32767 -l {} \; 2>&1 >&- | grep "^"'
-  # @TODO: Run a more extensive test using the above real WordPress installation
+  # Abort immediately if one step fails
+  # https://github.com/travis-ci/travis-ci/issues/1066#issuecomment-32415710
+  - set -e
+
+  # Run Codeception acceptance tests
+  # Run all codebase tests inside our Docker container
+  - >
+    docker run --name ${DOCKER_CONTAINER}
+    --hostname ${DOCKER_CONTAINER}
+    --volume /tmp/data/:/data
+    --volume ${PWD}:/data/wordpress
+    --env DEBUG=true
+    --rm
+    -it seravo/wordpress:ci


### PR DESCRIPTION
With this change into our project template, developers starting to develop
their projects on this template can just focus on having the right tests
in the .seravo-ci file, and Travis CI is already configured to start a
container from our CI Docker image. The .seravo-ci file contains some
example content.