### PR TITLE
Fix post-receive hook (Closes: #133)

### DIFF
--- a/scripts/git-hooks/post-receive
+++ b/scripts/git-hooks/post-receive
@@ -18,6 +18,10 @@ echo "Seravo: running post-receive git hook"
 ##
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. || exit
 
+# Git uses GIT_DIR instead of PWD by default.
+# This is still needed in addition to previous 'cd' when pushing to remote.
+GIT_DIR="$(pwd)/.git"
+
 # Loop through all changed files, only take pushes to master into consideration.
 # If you use some other branch for production, change "refs/heads/master" to
 # something else like "refs/heads/yourbranch".


### PR DESCRIPTION
GIT_DIR was removed in https://github.com/Seravo/wordpress/commit/e59b4f082e962ee33da2c2bb4979929d03dbc782 which caused some of the post-receive hook features not to work.