### PR TITLE
Enable image metadata stripping

### DIFF
--- a/htdocs/wp-content/install.php
+++ b/htdocs/wp-content/install.php
@@ -600,4 +600,5 @@ function seravo_plugin_options_enable() {
 
   // Image optimizer
   update_option('seravo-enable-optimize-images', 'on');
+  update_option('seravo-enable-strip-image-metadata', 'on');
 }


### PR DESCRIPTION
Enables wp-optimize-images' metadata stripping with Seravo Plugin (https://github.com/Seravo/seravo-plugin/pull/453)