### PR TITLE
Disconnect UART

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -157,6 +157,7 @@ Vagrant.configure('2') do |config|
     # Fix for slow external network connections
     vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
     vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
+    vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
   end
 
 end


### PR DESCRIPTION
This is needed in order to boot vagrant box v20201127.0.0 with Virtualbox 5.x.

This, however, does not fix the v20201127.0.0 for Virtualbox 6.x.

This is tricky to test, because I have no Virtualbox 5.x and @ottok has built the box v20201127.0.0 which makes it work for him.

This should not have side effects, so should be safe to merge :)

EDIT: This is also a preparation for next vagrant box release