### PR TITLE
Define minimal HSTS and CSP headers by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 Brought to you by [Seravo.com](https://seravo.com).
 
-A WordPress project layout for use with Git, Composer and Nginx. It also includes a config for an opinionated Vagrant box.
+A WordPress project layout for use with Git, Composer and Nginx. It also includes a config a Vagrant box and Docker image for local development.
 
-This same project layout is used by default on all [Seravo.com](https://seravo.com) instances for easy deployment workflow. Contents of this repository equals to what you would have on the server in the directory /data/wordpress/.
+This same project layout is used by default on all [Seravo.com](https://seravo.com) instances for easy deployment workflow. Contents of this repository equals to what you would have on the server in the directory `/data/wordpress/`.
 
 ## Documentation
 
@@ -18,17 +18,16 @@ Please see our documentation at https://seravo.com/docs/ on general information 
 > Please see our documentation at https://seravo.com/docs/development/how-to-install/ on how to install Vagrant and its dependencies.
 
 ## Features
-* Includes Nginx, MariaDB, PHP5, PHP7, HHVM, Redis and Git for running WordPress in modern stack.
+
+* Includes Nginx, MariaDB, PHP7, PHP8, Redis and Git for running WordPress in modern stack.
 * Git hooks to test your code to make sure that only high quality code is committed into git
 * Advanced WordPress acceptance tests with Codeception and headless Chrome
-* [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer) code style and quality analyser
+* [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer) code style and quality analyzer
 * Includes self-signed certs (and trust them automatically in OS X) to test https:// locally
 * [Xdebug](http://xdebug.org/) and [Webgrind](https://code.google.com/p/webgrind/) for debugging and profiling your application
 * [Mailcatcher](http://mailcatcher.me/) to imitate as SMTP server to debug mails
 * [Adminer](http://www.adminer.org/) for a graphical interface to manage your database
 * [BrowserSync](http://browsersync.io) as automatic testing middleware for WordPress
-
-Mailcatcher can be used to emulate emails use mailcatcher.wordpress.local (vagrant).
 
 ### Credentials for vagrant
 
@@ -46,9 +45,9 @@ password: root
 
 ## Development
 
-The layout of this repo is designed in a way which allows you to open source your site without exposing any confidential data. By default all sensitive data is ignored by git.
+The layout of this repo is designed in a way which allows storing the site in version control without exposing any confidential data. By default all sensitive data is ignored by git.
 
-All plugins are handled by composer so they are ignored by git. If you create custom plugins, force add them to git so that they are tracked or add new lines into .gitignore to not ignore.
+All plugins are handled by Composer so they are ignored by git. If you create custom plugins, force add them to git so that they are tracked or add new lines into `.gitignore` to not ignore.
 
 Example of not ignore line in `.gitignore`: `!htdocs/wp-content/plugins/your-plugin/`
 
@@ -70,9 +69,10 @@ You can do this by adding `composer.json` for your plugin/theme and then requiri
 ```
 
 ## Updates
-Vagrant will let you know as soon as a new version of the Vagrant box is available. You may download the newest box via `$ vagrant box update`
 
-To update your vagrant to use the new image run:
+Vagrant will let you know as soon as a new version of the Vagrant box is available.
+
+To download and update your Vagrant box to use the newest image run:
 ```
 $ vagrant box update
 $ vagrant destroy
@@ -82,44 +82,43 @@ $ vagrant up
 ## Configuration
 
 ### config.yml
+
 Change `name` in config.yml to change your site name. This is used in quite some places in development environment.
 
 Add `production => domain` and `production => ssh_port` to sync with your production instance.
 
 Add new domains under `development => domains` before first vagrant up to have extra domains.
 
-See `config-sample.yml` for more
+See `config-sample.yml` for more.
 
 ## The Layout
 
 The root of this repository equals the contents of the directory `/data/wordpress` in the Seravo.com instance.
 
 ```
-├── config.yml # See about Configuration above
-├── composer.json # Use composer for package handling
-├── composer.lock
-├── gulpfile.js # Example for using gulp
-├── Vagrantfile # Advanced vagrant environment and scripts packaged in Vagrantfile
+├── config.yml # Project name, domains and other configuration
+├── composer.json # Composer definition, used to pull in WordPress and plugins
+├── composer.lock # Composer lock file. This is safe to delete and ignore as detailed dependency control is not relevant in WordPress.
+├── gulpfile.js # Gulp example with correct paths
+├── Vagrantfile # Vagrantfile for Seravo/WordPress Vagrant box
 │
-├── tests # Here you can include tests for your WordPress instance
-│
-├── nginx # Here you can have your custom modifications to Nginx which are also used in production
+├── nginx # Custom modifications to Nginx which are also used in production
 │   └── examples.conf # Some examples to get started
-│   └── anything.conf # Your own config files can be named anything *.conf.
+│   └── anything.conf # Your own config files can be named anything *.conf
 │
 ├── scripts
 │   ├── hooks # Git hooks for your project
-│   │   ├── pre-commit # This is run after every commit
-│   │   └──
+│   │   ├── pre-commit # Run after every git commit
+│   │   └── post-receive # Run after every git pull/push
 │   │
 │   ├── WordPress
-│   │   └── Installer.php # Additional composer scripts
+│   │   └── Installer.php # Composer helper for WordPress installation
 │   │
-│   └── run-tests # Bash-script as an interface for your tests in Seravo's production and development environments
+│   └── run-tests # Bash script as an interface for your tests in Seravo's production and development environments
 │
 ├── vendor # Composer packages go here
-└── htdocs # This is the web root of your site
-    ├── wp-content # wp-content is moved out of core
+└── htdocs # The web root of your site
+    ├── wp-content # Directory moved out of WordPress core for git compatibility
     │   ├── mu-plugins
     │   ├── plugins
     │   ├── themes
@@ -127,19 +126,15 @@ The root of this repository equals the contents of the directory `/data/wordpres
     ├── wp-config.php
     ├── wp-load.php
     ├── index.php
-    └── wordpress # WordPress Core installed by composer
+    └── wordpress # WordPress core
         ├── wp-admin
         ├── index.php
         └── ...
 ```
 
-## WordPress plugins
-
-The composer.json contains some plugins and themes that are likely to be useful for pretty much every installation. For particular use cases see our list of recommended plugins at http://wp-palvelu.fi/lisaosat/
-
-Note that all plugins are installed, but not active by default. To activate them, run `vagrant ssh -c "wp plugin activate --all"`.
-
 ## Credits
 
-Directory layout heavily inspired by [roots/bedrock](https://github.com/roots/bedrock)
-Development stack inspired by [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
+* Directory layout heavily inspired by [roots/bedrock](https://github.com/roots/bedrock)
+* Development stack inspired by [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
+
+Copyright Seravo Oy, 2015–2021 and contributors. Available under the GPLv3 license.

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,9 @@
 
     "seravo/seravo-plugin": "*",
 
-    "wpackagist-plugin/native-lazyload": "*",
     "wpackagist-plugin/google-site-kit": "*",
+    "wpackagist-plugin/two-factor": "*",
+    "wpackagist-plugin/wp-recaptcha-integration": "*",
 
     "wpackagist-theme/twentynineteen": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -2,27 +2,10 @@
   "name": "seravo/wordpress",
   "type": "project",
   "license": "MIT",
-  "description": "Seravo WordPress instance template",
+  "description": "Seravo WordPress project template",
   "homepage": "https://seravo.com/",
-  "authors": [
-    {
-      "name": "Antti Kuosmanen",
-      "email": "antti@seravo.fi",
-      "homepage": "https://github.com/anttiviljami"
-    },
-    {
-      "name": "Otto Kekäläinen",
-      "email": "otto@seravo.fi",
-      "homepage": "https://github.com/ottok"
-    },
-    {
-      "name": "Onni Hakala",
-      "email": "onni@seravo.fi",
-      "homepage": "https://github.com/onnimonni"
-    }
-  ],
   "keywords": [
-    "wordpress", "composer", "wp", "wp-palvelu", "seravo"
+    "wordpress", "composer", "wp", "vagrant", "docker", "wp-palvelu", "seravo"
   ],
   "config": {
     "preferred-install": "dist"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,47 +12,57 @@ var reload      = browserSync.reload;
  * Choose your theme over here
  */
 var src = {
-    scss: 'htdocs/wp-content/themes/yourtheme/scss/*.scss',
-    css:  'htdocs/wp-content/themes/yourtheme/css',
-    php: [
-        'htdocs/wp-content/themes/*/*.php',
-        'htdocs/wp-content/plugins/*/*.php',
-        'htdocs/wp-content/mu-plugins/*/*.php'
-    ]
+  scss: 'htdocs/wp-content/themes/yourtheme/scss/*.scss',
+  css:  'htdocs/wp-content/themes/yourtheme/css',
+  php: [
+    'htdocs/wp-content/themes/*/*.php',
+    'htdocs/wp-content/plugins/*/*.php',
+    'htdocs/wp-content/mu-plugins/*/*.php'
+  ]
 };
 
 // Compile sass into CSS
-gulp.task('sass', () => {
+gulp.task(
+  'sass',
+  () =>
+  {
     return gulp.src(src.scss)
-        .pipe(sass())
-        .pipe(gulp.dest(src.css))
-        .pipe(reload({stream: true}));
-});
+      .pipe(sass())
+      .pipe(gulp.dest(src.css))
+      .pipe(reload({stream: true}));
+  }
+);
 
 // Serve all files through browser-sync
-gulp.task('serve', gulp.series('sass', () => {
-
-    // Initialize browsersync
-    // Nginx is configured to use any service in port 1337
-    // as middleware to WordPress in vagrant environment
-    browserSync.init({
-        // browsersync with a php server
-        proxy: "https://wordpress.local",
-        port: 1337,
-        ui: {
-            port: 1338
-        },
-        notify: true
-    });
-
-    // Watch sass files and compile them. Use polling because the Virtualbox
-    // shared folders implementation does not emit file system events from the
-    // host to the VM: https://github.com/floatdrop/gulp-watch/issues/213.
-    gulp.watch(src.scss, { usePolling: true }, gulp.series('sass'));
-
-    // Update the page automatically if php files change
-    gulp.watch(src.php, { usePolling: true }).on('change', reload);
-}));
+gulp.task(
+  'serve',
+  gulp.series(
+    'sass',
+    () =>
+    {
+      // Initialize browsersync
+      // Nginx is configured to use any service in port 1337
+      // as middleware to WordPress in vagrant environment
+      browserSync.init(
+        {
+          // browsersync with a php server
+          proxy: "https://wordpress.local",
+          port: 1337,
+          ui: {
+              port: 1338
+          },
+          notify: true
+        }
+      );
+      // Watch sass files and compile them. Use polling because the Virtualbox
+      // shared folders implementation does not emit file system events from the
+      // host to the VM: https://github.com/floatdrop/gulp-watch/issues/213.
+      gulp.watch(src.scss, { usePolling: true }, gulp.series('sass'));
+      // Update the page automatically if php files change
+      gulp.watch(src.php, { usePolling: true }).on('change', reload);
+    }
+  )
+);
 
 // Give another name for serve
 gulp.task('watch', gulp.series('serve'));

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -1,6 +1,4 @@
 <?php
-
-
 // WordPress view bootstrapper
 define('WP_USE_THEMES', true);
 require dirname( __FILE__ ) . '/wordpress/wp-blog-header.php';

--- a/htdocs/wp-config.php
+++ b/htdocs/wp-config.php
@@ -6,11 +6,8 @@
 ##### https://seravo.com/docs/development/environment-variables/          #####
 ###############################################################################
 
-# Load composer libraries
+// Load Composer libraries
 require_once dirname(__DIR__) . '/vendor/autoload.php';
-
-$root_dir = dirname(__DIR__);
-$webroot_dir = $root_dir . '/htdocs';
 
 /**
  * Use Dotenv to load environment variables from a .env file at project root.
@@ -20,11 +17,10 @@ $webroot_dir = $root_dir . '/htdocs';
  * The syntax below is written for Dotenv 5.x. For changes to previous versions
  * see  https://github.com/vlucas/phpdotenv/blob/master/UPGRADING.md
  */
-if ( file_exists($root_dir . '/.env') ) {
-  $dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir);
+if ( file_exists(dirname(__DIR__) . '/.env') ) {
+  $dotenv = Dotenv\Dotenv::createUnsafeImmutable(dirname(__DIR__));
   $dotenv->load();
 }
-
 
 /**
  * DB settings
@@ -42,7 +38,7 @@ $table_prefix = getenv('DB_PREFIX') ? getenv('DB_PREFIX') : 'wp_';
  * Content Directory is moved out of the wp-core.
  */
 define('CONTENT_DIR', '/wp-content');
-define('WP_CONTENT_DIR', $webroot_dir . CONTENT_DIR);
+define('WP_CONTENT_DIR', dirname(__DIR__) . '/htdocs' . CONTENT_DIR);
 
 // WP_CONTENT_URL can be set to enable relative URLs to /wp-content
 // but if undefined, it simply defaults to absolute URLs.
@@ -117,7 +113,7 @@ ini_set('log_errors', 'On');
 
 /** Absolute path to the WordPress directory. */
 if ( ! defined('ABSPATH') ) {
-  define('ABSPATH', $webroot_dir . '/wordpress/');
+  define('ABSPATH', dirname(__DIR__) . '/htdocs/wordpress/');
 }
 
 require_once ABSPATH . 'wp-settings.php';

--- a/htdocs/wp-content/install.php
+++ b/htdocs/wp-content/install.php
@@ -164,19 +164,25 @@ function wp_install_defaults( $user_id ) {
     $cat_id = 1;
   }
 
-  $wpdb->insert( $wpdb->terms, array(
-    'term_id'    => $cat_id,
-    'name'       => $cat_name,
-    'slug'       => $cat_slug,
-    'term_group' => 0,
-  ) );
-  $wpdb->insert( $wpdb->term_taxonomy, array(
-    'term_id'     => $cat_id,
-    'taxonomy'    => 'category',
-    'description' => '',
-    'parent'      => 0,
-    'count'       => 1,
-  ));
+  $wpdb->insert(
+    $wpdb->terms,
+    array(
+      'term_id'    => $cat_id,
+      'name'       => $cat_name,
+      'slug'       => $cat_slug,
+      'term_group' => 0,
+    )
+  );
+  $wpdb->insert(
+    $wpdb->term_taxonomy,
+    array(
+      'term_id'     => $cat_id,
+      'taxonomy'    => 'category',
+      'description' => '',
+      'parent'      => 0,
+      'count'       => 1,
+    )
+  );
   $cat_tt_id = $wpdb->insert_id;
 
   // Seravo: Don't create first post and comment to make the install cleaner
@@ -195,31 +201,37 @@ function wp_install_defaults( $user_id ) {
   }
 
   $first_post_guid = get_option('home') . '/?page_id=1';
-  $wpdb->insert( $wpdb->posts, array(
-    'id'                    => 1,
-    'post_author'           => $user_id,
-    'post_date'             => $now,
-    'post_date_gmt'         => $now_gmt,
-    'post_content'          => $first_page,
-    'post_excerpt'          => '',
-    'comment_status'        => 'closed',
-    'post_title'            => seravo_page_title(),
-    /* translators: Default page slug */
-    // Seravo: Set a slug that makes sense and dont interfere with possible other content
-    'post_name'             => __( 'seravo-start' ),
-    'post_modified'         => $now,
-    'post_modified_gmt'     => $now_gmt,
-    'guid'                  => $first_post_guid,
-    'post_type'             => 'page',
-    'to_ping'               => '',
-    'pinged'                => '',
-    'post_content_filtered' => '',
-  ));
-  $wpdb->insert( $wpdb->postmeta, array(
-    'post_id'    => 1,
-    'meta_key'   => '_wp_page_template',
-    'meta_value' => 'default',
-  ) );
+  $wpdb->insert(
+    $wpdb->posts,
+    array(
+      'id'                    => 1,
+      'post_author'           => $user_id,
+      'post_date'             => $now,
+      'post_date_gmt'         => $now_gmt,
+      'post_content'          => $first_page,
+      'post_excerpt'          => '',
+      'comment_status'        => 'closed',
+      'post_title'            => seravo_page_title(),
+      /* translators: Default page slug */
+      // Seravo: Set a slug that makes sense and dont interfere with possible other content
+      'post_name'             => __( 'seravo-start' ),
+      'post_modified'         => $now,
+      'post_modified_gmt'     => $now_gmt,
+      'guid'                  => $first_post_guid,
+      'post_type'             => 'page',
+      'to_ping'               => '',
+      'pinged'                => '',
+      'post_content_filtered' => '',
+    )
+  );
+  $wpdb->insert(
+    $wpdb->postmeta,
+    array(
+      'post_id'    => 1,
+      'meta_key'   => '_wp_page_template',
+      'meta_value' => 'default',
+    )
+  );
 
   // Privacy Policy page
   if ( is_multisite() ) {
@@ -293,10 +305,13 @@ function wp_install_defaults( $user_id ) {
 
     // Delete any caps that snuck into the previously active blog. (Hardcoded to blog 1 for now.) TODO: Get previous_blog_id.
     if ( ! is_super_admin( $user_id ) && $user_id != 1 ) {
-      $wpdb->delete( $wpdb->usermeta, array(
-        'user_id'  => $user_id,
-        'meta_key' => $wpdb->base_prefix . '1_capabilities',
-      ) );
+      $wpdb->delete(
+        $wpdb->usermeta,
+        array(
+          'user_id'  => $user_id,
+          'meta_key' => $wpdb->base_prefix . '1_capabilities',
+        )
+      );
     }
   }
 
@@ -569,9 +584,9 @@ function seravo_install_activate_plugins() {
   }
 
   // Activate plugins if they can be found from installed plugins
-  foreach ($all_plugins as $plugin_path => $data) {
-    $plugin_name = explode('/',$plugin_path)[0]; // get the folder name from plugin
-    if (in_array($plugin_name,$plugins)) { // If plugin is installed activate it
+  foreach ( $all_plugins as $plugin_path => $data ) {
+    $plugin_name = explode('/', $plugin_path)[0]; // get the folder name from plugin
+    if ( in_array($plugin_name, $plugins) ) { // If plugin is installed activate it
       // Do the activation
       include_once(WP_PLUGIN_DIR . '/' . $plugin_path);
       do_action('activate_plugin', $plugin_path);

--- a/htdocs/wp-load.php
+++ b/htdocs/wp-load.php
@@ -1,8 +1,9 @@
 <?php
 /*
- * Usually wp-content is inside WordPress core
- * In this project wp-content is moved out of core to be easier to update.
- * Especially with composer.
+ * Usually wp-content is inside WordPress core, but in this project template it
+ * is moved out of core wordpress directory, which is an ignored directory in
+ * git and which might also get occasionally wiped out by Composer runs.
+ *
  └── htdocs
     ├── wp-content
     │   ├── mu-plugins
@@ -12,20 +13,18 @@
     ├── wp-config.php
     ├── index.php
     ├── wp-load.php
-    └── wordpress # WordPress Core installed by composer
+    └── wordpress # WordPress core installed by Composer
         ├── wp-admin
         ├── index.php
         ├── wp-load.php
         └── ...
+ *
  * Some popular plugins have an antipattern to do this:
+ *   require_once('../../../wp-load.php');
  *
- * require_once('../../../wp-load.php');
+ * They require wp-load.php straight from core usually to have some special ajax
+ * functionality. This file is where wp-load.php would typically be and fixes
+ * these problems by requiring wp-load.php from where it really is.
  *
- * They require wp-load.php straight from core usually to have some special ajax functionality.
- *
- * This file is where wp-load.php would typically be and fixes these problems by requiring wp-load.php
- * from where it really is.
- *
- * Author: Onni Hakala / Seravo Oy
  */
 require_once 'wordpress/wp-load.php';

--- a/nginx/examples.conf
+++ b/nginx/examples.conf
@@ -28,16 +28,6 @@
 #rewrite ^/original http://example.com/new/url/ permanent;
 
 ###
-## Force https and send headers that tell browsers that https is always preferred.
-## For additional security add 'includeSubDomains; preload'.
-## Test you have correct settings with https://hstspreload.org/
-###
-#if ( $ssl = false  ) {
-#  return 301 https://$http_host$request_uri;
-#}
-#add_header Strict-Transport-Security "max-age=63072000;";
-
-###
 ## Disable caching completely when developing the site. Do not emit these
 ## headers in production as it would decrease the performance of the site.
 ## Note: This is much better controlled by constant WP_DEBUG in wp-config.php

--- a/nginx/security.conf
+++ b/nginx/security.conf
@@ -1,0 +1,13 @@
+###
+## Send headers that tell browsers that https is always preferred.
+## Test that you have correct HSTS settings with https://hstspreload.org/
+## and CSP with https://csp-evaluator.withgoogle.com/
+###
+
+# Minimal HSTS header that is safe on all sites. Expand this is needed.
+# For additional security add 'includeSubDomains; preload'.
+add_header Strict-Transport-Security "max-age=63072000;";
+
+# Minimal CSP config that is safe on all sites. Expand this is needed.
+add_header Content-Security-Policy "upgrade-insecure-requests";
+

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0"?>
+<ruleset name="Seravo">
+  <description>
+    Seravo coding standards definition. Mostly WordPress coding standards, but
+    relaxed a bit to be easier on developers. This is provided as an example on
+    howto use phpcs.xml in this project template. Modify this to suit your own
+    preferences. Read more at https://seravo.com/tag/phpcs/
+  </description>
+
+  <!-- Show sniff progress -->
+  <arg value="p"/>
+
+  <!-- All files should be UTF-8 encoded. -->
+  <arg name="encoding" value="utf-8"/>
+
+  <!-- check current and all subfolders if no file parameter given. -->
+  <file>.</file>
+
+  <!-- Don't check our installation script -->
+  <exclude-pattern>/wp-content/install.php</exclude-pattern>
+  <exclude-pattern>/scripts/WordPress/Installer.php</exclude-pattern>
+
+  <!-- Don't check composer dependencies and extras -->
+  <exclude-pattern>/vendor/</exclude-pattern>
+
+  <!-- Don't check WP core or project template files -->
+  <exclude-pattern>/htdocs/index.php</exclude-pattern>
+  <exclude-pattern>/htdocs/wp-load.php</exclude-pattern>
+  <exclude-pattern>/htdocs/wp-config.php</exclude-pattern>
+  <exclude-pattern>/htdocs/wp-content/object-cache.php</exclude-pattern>
+  <exclude-pattern>/htdocs/wp-content/object-cache.php.off</exclude-pattern>
+  <exclude-pattern>/htdocs/wp-content/mu-plugins/bedrock-autoloader.php</exclude-pattern>
+  <exclude-pattern>/htdocs/wp-content/mu-plugins/register-theme-directory.php</exclude-pattern>
+
+  <!--
+    Exclude all but plugins that are developed in this branch. PHPCS does not
+    support exclude+include so we need this list.
+  -->
+  <exclude-pattern>/htdocs/wp-content/plugins/google-site-kit</exclude-pattern>
+  <exclude-pattern>/htdocs/wp-content/plugins/maintenance</exclude-pattern>
+  <exclude-pattern>/htdocs/wp-content/plugins/two-factor</exclude-pattern>
+  <exclude-pattern>/htdocs/wp-content/plugins/wp-recaptcha-integration</exclude-pattern>
+
+  <!-- Exclude Node.js modules -->
+  <exclude-pattern>/node_modules/</exclude-pattern>
+
+  <!--
+    Exclude CodeCeption tests to prevent errors: "Variable "$I" is not in
+    valid snake_case format, try "$i"".
+  -->
+  <exclude-pattern>/codeception/</exclude-pattern>
+
+  <!-- Exclude uploads where some plugins stores PHP files (unfortunately) -->
+  <exclude-pattern>/htdocs/wp-content/uploads/</exclude-pattern>
+
+  <!-- Don't check dependencies which are named as "libraries" -->
+  <exclude-pattern>/libraries/</exclude-pattern>
+
+  <!-- Don't check minified assets -->
+  <exclude-pattern>*.min.js</exclude-pattern>
+  <exclude-pattern>*.min.css</exclude-pattern>
+
+  <!-- Not excluded: wp-content/themes -->
+
+  <!-- Extend the exclude patterns to match your .gitignore -->
+
+
+  <!--
+    Include WordPress Coding Standards with some exclusions. WordPress-Extra contains an extended
+    ruleset for recommended best practices, see
+    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#rulesets for details
+    about different WordPress subsets.
+  -->
+  <rule ref="WordPress-Extra">
+
+    <!-- Allow spaces in indentation -->
+    <exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
+
+    <!-- Don't use precision alignment -->
+    <exclude name="WordPress.WhiteSpace.PrecisionAlignment" />
+
+    <!--
+      The generic exact whitespace sniff does not work very well with inline HTML, so ignore it.
+    -->
+    <exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+
+    <!--
+      Exclude WordPress array indent as it causes false positivies, is not very customizable
+      and we already use Generic.Arrays.ArrayIndent.
+    -->
+    <exclude name="WordPress.Arrays.ArrayIndentation.ItemNotAligned" />
+
+
+    <!--
+      Causes false errors "Multi-line array item not aligned correctly" when indenting with
+      2 spaces instead of 4.
+    -->
+    <exclude name="WordPress.Arrays.ArrayIndentation.MultiLineArrayItemNotAligned" />
+
+    <!-- There is no need to align equals signs or array keys -->
+    <exclude name="Generic.Formatting.MultipleStatementAlignment" />
+    <exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
+
+    <!--
+      Don't enforce the usage of excessive amounts of whitespace around opening/closing
+      brackets and around variables as array keys.
+    -->
+    <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
+    <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+    <exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions" />
+
+    <!-- Yoda Condition checks reduce code readability with very little benefit -->
+    <exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+
+    <!-- Don't enforce the usage of class files with name "class-*.php". -->
+    <exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+
+    <!-- We need to use PHP system calls to provide grahpical wrappers for CLI commands. -->
+    <exclude name="WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec" />
+
+    <!--
+      Don't enforce the usage of escaped output in every situation, the security risks should be
+      assessed separately. Also we can't always use nonces e.g. for APIs...
+    -->
+    <exclude name="WordPress.Security.EscapeOutput.UnsafePrintingFunction" />
+    <exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped" />
+    <exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" />
+    <exclude name="WordPress.Security.NonceVerification" />
+
+    <!-- We have valid use cases for localized dates, so ingore this -->
+    <exclude name="WordPress.DateTime.RestrictedFunctions.date_date" />
+
+    <!-- Alone line with 'function($) {' is fully OK -->
+    <exclude name="PEAR.Functions.FunctionCallSignature.FirstArgumentPosition" />
+  </rule>
+
+
+  <!-- Include Security sniffs -->
+  <rule ref="Security">
+    <!--
+      Ignore the ErrMiscIncludeMismatchNoExt sniff because it causes
+      unnecessary errors on dynamically reated require paths, e.g.
+      >>> require_once 'something-' . $somevar . '.php';
+    -->
+    <exclude name="PHPCS_Security.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt" />
+  </rule>
+
+
+  <!-- Include PHP compatibility sniffs -->
+  <rule ref="PHPCompatibility" />
+
+
+  <!--
+    Add some custom sniff rules in this section below. See
+    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties and
+    https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
+    for available sniffs and their properties.
+  -->
+
+  <!-- Set 2 spaces indentation for function call signature -->
+  <rule ref="PEAR.Functions.FunctionCallSignature">
+    <properties>
+      <property name="indent" value="2" />
+      <property name="requiredSpacesAfterOpen" value="0"/>
+      <property name="requiredSpacesBeforeClose" value="0"/>
+      <property name="allowMultipleArguments" value="false"/>
+    </properties>
+  </rule>
+
+  <!--
+    Indent using two (2) spaces instead of tabs. Otherwise, use the same settings as WP Core
+    sniffs use.
+  -->
+  <rule ref="Generic.WhiteSpace.ScopeIndent">
+    <properties>
+      <property name="exact" value="false"/>
+      <property name="indent" value="2"/>
+      <property name="tabIndent" value="false"/>
+      <property name="ignoreIndentationTokens" type="array">
+        <element value="T_HEREDOC"/>
+        <element value="T_NOWDOC"/>
+        <element value="T_INLINE_HTML"/>
+      </property>
+    </properties>
+  </rule>
+
+  <!--
+    The soft limit on line length is 100 characters. However, do not trigger errors if the limit
+    is exceeded.
+  -->
+  <rule ref="Generic.Files.LineLength">
+    <properties>
+      <property name="lineLimit" value="100"/>
+      <property name="absoluteLineLimit" value="0"/>
+    </properties>
+  </rule>
+
+  <!-- Set 2 spaces indentation for switch terminating case statement -->
+  <rule ref="PSR2.ControlStructures.SwitchDeclaration">
+    <properties>
+      <property name="indent" value="2" />
+    </properties>
+  </rule>
+
+  <!-- Enforce that multiline arrays are indented with two spaces -->
+  <rule ref="Generic.Arrays.ArrayIndent">
+    <properties>
+      <property name="tabIndent" value="false" />
+      <property name="indent" value="2" />
+    </properties>
+  </rule>
+
+  <!-- Explicitly forbid tabs -->
+  <rule ref="Generic.WhiteSpace.DisallowTabIndent" />
+
+</ruleset>

--- a/scripts/WordPress/Installer.php
+++ b/scripts/WordPress/Installer.php
@@ -20,7 +20,7 @@ class Installer {
     if ( ! is_link($wp_core_content_folder) ) {
       if ( file_exists($wp_core_content_folder) ) {
         self::rrmdir($wp_core_content_folder);
-        if ( self::isWindows() ) {
+        if ( self::is_windows() ) {
           $io->write('Windows: Removed wp-content from core');
         } else {
           // Symlink shouldn't be necessary
@@ -64,7 +64,7 @@ class Installer {
    *
    * @return bool
    */
-  private static function isWindows() {
+  private static function is_windows() {
     if ( strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ) {
       return true;
     } else {


### PR DESCRIPTION
Remove HTTPS redirect as it occasionally interferes with valid http
request that e.g. want to validate certs via ACME HTTP method.

The HTTP->HTTPS redirect is anyway done by default WordPress itself to
ensure canonical domains and in general redirects are better done in PHP
anyway.