### PR TITLE
Automatically run Gulp is SCSS/SASS files have changes

### DIFF
--- a/scripts/git-hooks/post-receive
+++ b/scripts/git-hooks/post-receive
@@ -18,19 +18,33 @@ echo "Seravo: running post-receive git hook"
 ##
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. || exit
 
-# Git uses GIT_DIR instead of PWD by default.
-# This is still needed in addition to previous 'cd' when pushing to remote.
+# When GIT_DIR is defined, git uses it instead of PWD.
+# The git dir needs to be defined as the 'cd' is not enough.
+# shellcheck disable=SC2034
 GIT_DIR="$(pwd)/.git"
 
-# Loop through all changed files, only take pushes to master into consideration.
-# If you use some other branch for production, change "refs/heads/master" to
-# something else like "refs/heads/yourbranch".
-changed_files=""
-while read -r oldrev newrev refname; do
-  if [ "$refname" = "refs/heads/master" ]; then
-    changed_files=$(git diff-tree --name-only -r "$oldrev" "$newrev")
-  fi
-done
+# Check if something was piped to this script, which typically happens when the
+# git hook is triggered. If not, then just run hook on HEAD.
+if [ -t 0 ]
+then
+  echo "*** Seems the stdin is empty, executing git hook as if all files changed ***"
+  changed_files=$(find -- *)
+else
+  # Loop through all changed files, only take pushes to master into consideration.
+  # If you use some other branch for production, change "refs/heads/master" to
+  # something else like "refs/heads/yourbranch".
+  changed_files=""
+  while read -r oldrev newrev refname
+  do
+    echo "Branch: $refname"
+    echo "Previous commit: $oldrev"
+    echo "New commit: $newrev"
+    if [ "$refname" = "refs/heads/master" ]
+    then
+      changed_files=$(git diff-tree --name-only -r "$oldrev" "$newrev")
+    fi
+  done
+fi
 
 # Check files which have triggers
 COMPOSER_CHANGED=false

--- a/scripts/git-hooks/post-receive
+++ b/scripts/git-hooks/post-receive
@@ -5,6 +5,9 @@
 # actions when doing a 'git push production'.
 #
 # $ cd .git/hooks; ln -s ../../scripts/git-hooks/post-receive .
+#
+# To also trigger on `git pull` define `post-merge` as well:
+# $ ln -s ../../scripts/git-hooks/post-receive post-merge
 ##
 
 # This file prepends output with "Seravo:" so that people running 'git push'

--- a/scripts/git-hooks/post-receive
+++ b/scripts/git-hooks/post-receive
@@ -35,25 +35,37 @@ done
 # Check files which have triggers
 COMPOSER_CHANGED=false
 NGINX_CHANGED=false
+SCSS_CHANGED=false
 while read -r line; do
-    if [ "$line" = "composer.json" ] || [ "$line" = "composer.lock" ]; then
+    if [ "$line" = "composer.json" ] || [ "$line" = "composer.lock" ]
+    then
       COMPOSER_CHANGED=true
-    elif [ "$line" = "nginx/*.conf" ]; then
+    elif [ "$line" = "nginx/*.conf" ]
+    then
       NGINX_CHANGED=true
+    elif [[ "$line" =~ \.scss ]]
+    then
+      SCSS_CHANGED=true
     fi
 done <<< "$changed_files"
 
 # Do stuff with the triggers
-if $COMPOSER_CHANGED; then
+if $COMPOSER_CHANGED
+then
   echo "Seravo: composer.json was updated, installing..."
   composer install --no-dev
 fi
 
-if $NGINX_CHANGED; then
+if $NGINX_CHANGED
+then
   echo "Seravo: Nginx configs were changed, reloading nginx..."
   wp-restart-nginx
 fi
 
+if $SCSS_CHANGED; then
+  echo "Seravo: SASS files changed, running Gulp..."
+  gulp
+fi
 
 # If there is a Tideways key set, use it to trigger a release event
 if [ -f /data/wordpress/.tideways.key ] && [ ! -z "$(cat /data/wordpress/.tideways.key)" ]


### PR DESCRIPTION
"Screenshot":

```
laptop$ git push production
Counting objects: 8, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (8/8), done.
Writing objects: 100% (8/8), 667 bytes | 667.00 KiB/s, done.
Total 8 (delta 7), reused 0 (delta 0)
remote: Seravo: running post-receive git hook
remote: Seravo: SASS files changed, running Gulp...
remote: [21:07:07] Using gulpfile /data/wordpress/gulpfile.js
remote: [21:07:07] Starting 'default'...
remote: [21:07:07] Starting 'build'...
remote: [21:07:07] Starting 'sass'...
remote: [21:07:08] Finished 'sass' after 257 ms
remote: [21:07:08] Starting 'js'...
remote: [21:07:09] Finished 'js' after 1.16 s
remote: [21:07:09] Finished 'build' after 1.42 s
remote: [21:07:09] Finished 'default' after 1.42 s
remote: Found Tideways API key: abc123
remote: {"apiKey": "abc123", "name": "894405ac", "type": "release", "environment": "", "service": "web", "compareAfterMinutes":90}
remote: ==> Tideways event registered successfully!
remote: Seravo: Flushing all caches...
remote: ----> Purging WordPress object cache...
remote: Success: The cache was flushed.
remote: ----> Flush WordPress rewrites...
remote: Success: Rewrite rules flushed.
remote: ----> Flush the entire Redis cache (includes Nginx PageSpeed cache etc)...
remote: OK
remote: ----> Success
remote: ----> Purging Nginx page cache...
remote: Cache purged successfully for production.
remote: Error: Couldn't purge cache. Could be empty already.
remote: Cache purged successfully for production.
remote: Error: Couldn't purge cache. Could be empty already.
To production:/data/wordpress
   124ebbc4..894405ac  master -> master
```