### PR TITLE
Define WPML_CACHE_PATH_ROOT to have it in a standard cache directory

### DIFF
--- a/htdocs/wp-config.php
+++ b/htdocs/wp-config.php
@@ -70,6 +70,12 @@ define('FORCE_SSL_ADMIN', true);
 /**
  * Custom Settings
  */
+
+/**
+ * Standardize cache location to have as much as possible in wp-content/cache
+ * so that it is easier to develop tools to accelerate or purge caches.
+ */
+define('WPML_CACHE_PATH_ROOT', dirname(__DIR__) . '/htdocs/wp-content/cache/wpml/');
 define('AUTOMATIC_UPDATER_DISABLED', true); /* automatic updates are handled by wordpress-palvelu */
 define('DISALLOW_FILE_EDIT', true); /* disable the theme/plugin file editor */
 define('PLL_COOKIE', false); /* allow caching sites with polylang, disable if weird issues occur */

--- a/htdocs/wp-config.php
+++ b/htdocs/wp-config.php
@@ -68,17 +68,27 @@ define('NONCE_SALT',       getenv('NONCE_SALT'));
 define('FORCE_SSL_ADMIN', true);
 
 /**
- * Custom Settings
+ * Disable automatic updates and use Seravo updates instead
  */
+define('AUTOMATIC_UPDATER_DISABLED', true);
+
+/*
+ * Disable the theme/plugin file editor for security reasons
+ */
+define('DISALLOW_FILE_EDIT', true);
+
+/*
+ * Prevent Polylang from setting extra language cookies, so that the HTTP cache
+ * is not busted in vain. The language is anyway in the request URL (e.g. /en/)
+ * so extra language cookies are not needed.
+ */
+define('PLL_COOKIE', false);
 
 /**
  * Standardize cache location to have as much as possible in wp-content/cache
  * so that it is easier to develop tools to accelerate or purge caches.
  */
 define('WPML_CACHE_PATH_ROOT', dirname(__DIR__) . '/htdocs/wp-content/cache/wpml/');
-define('AUTOMATIC_UPDATER_DISABLED', true); /* automatic updates are handled by wordpress-palvelu */
-define('DISALLOW_FILE_EDIT', true); /* disable the theme/plugin file editor */
-define('PLL_COOKIE', false); /* allow caching sites with polylang, disable if weird issues occur */
 
 /**
  * Only keep the last 30 revisions of a post. Having hundreds of revisions of


### PR DESCRIPTION
Change verified to work:
```
/data/wordpress/htdocs] $ find wp-content/cache/
wp-content/cache/
wp-content/cache/wpml
wp-content/cache/wpml/wpml
wp-content/cache/wpml/wpml/twig
wp-content/cache/wpml/wpml/twig/6a
wp-content/cache/wpml/wpml/twig/6a/6a312ce335003814601401a12f974ba29db9f83a3d811095a8866e3b460c6d4b.php
```