### PR TITLE
Limit virtual CPUs to max 2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -152,6 +152,11 @@ Vagrant.configure('2') do |config|
       else 2
     end
 
+    # Having too many CPUs will not make the machine faster, so limit to max 2
+    if cpus > 2
+      cpus = 2
+    end
+
     # Customize memory in MB
     vb.customize ['modifyvm', :id, '--memory', 1536]
     vb.customize ['modifyvm', :id, '--cpus', cpus]


### PR DESCRIPTION
Having more CPU does not in tests make the VirtualBox virtual machine
any faster. On the contrary it seems to slow down the whole host
occasionally.

Unfortunately I don't have any data to prove this. On the other hand,
seems sensible and no harm done if it wasn't fully true, as 2 CPUs is
enough anyway.