### PR TITLE
Change wp-test-ng to wp-test

### DIFF
--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -137,7 +137,7 @@ done
 #
 # Block commit if tests fail.
 ##
-if ! /usr/local/bin/wp-test-ng --debug --fail-fast
+if ! /usr/local/bin/wp-test --debug --fail-fast
 then
   echo "==> Tests failed! Git commit denied."
   exit 1


### PR DESCRIPTION
wp-test was updated to new generation on March 31st in 2019, so using wp-test-ng is not necessary at this point.