### PR TITLE
Set BrowserSync address dynamically

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,10 +2,10 @@
  * This is default barebone for gulp, add your own modifications here
  * It also serves as an example of how to use browser-sync in this environment
  */
-var gulp        = require('gulp');
+var gulp = require('gulp');
 var browserSync = require('browser-sync');
-var sass        = require('gulp-sass');
-var reload      = browserSync.reload;
+var sass = require('gulp-sass');
+var reload = browserSync.reload;
 
 /*
  * src array contains the files which the gulp will be watching
@@ -13,55 +13,47 @@ var reload      = browserSync.reload;
  */
 var src = {
   scss: 'htdocs/wp-content/themes/yourtheme/scss/*.scss',
-  css:  'htdocs/wp-content/themes/yourtheme/css',
+  css: 'htdocs/wp-content/themes/yourtheme/css',
   php: [
     'htdocs/wp-content/themes/*/*.php',
     'htdocs/wp-content/plugins/*/*.php',
-    'htdocs/wp-content/mu-plugins/*/*.php'
-  ]
+    'htdocs/wp-content/mu-plugins/*/*.php',
+  ],
 };
 
 // Compile sass into CSS
-gulp.task(
-  'sass',
-  () =>
-  {
-    return gulp.src(src.scss)
-      .pipe(sass())
-      .pipe(gulp.dest(src.css))
-      .pipe(reload({stream: true}));
-  }
-);
+gulp.task('sass', () => {
+  return gulp
+    .src(src.scss)
+    .pipe(sass())
+    .pipe(gulp.dest(src.css))
+    .pipe(reload({ stream: true }));
+});
 
 // Serve all files through browser-sync
 gulp.task(
   'serve',
-  gulp.series(
-    'sass',
-    () =>
-    {
-      // Initialize browsersync
-      // Nginx is configured to use any service in port 1337
-      // as middleware to WordPress in vagrant environment
-      browserSync.init(
-        {
-          // browsersync with a php server
-          proxy: "https://wordpress.local",
-          port: 1337,
-          ui: {
-              port: 1338
-          },
-          notify: true
-        }
-      );
-      // Watch sass files and compile them. Use polling because the Virtualbox
-      // shared folders implementation does not emit file system events from the
-      // host to the VM: https://github.com/floatdrop/gulp-watch/issues/213.
-      gulp.watch(src.scss, { usePolling: true }, gulp.series('sass'));
-      // Update the page automatically if php files change
-      gulp.watch(src.php, { usePolling: true }).on('change', reload);
-    }
-  )
+  gulp.series('sass', () => {
+    // Initialize browsersync
+    // Nginx is configured to use any service in port 1337
+    // as middleware to WordPress in vagrant environment
+    browserSync.init({
+      // browsersync with a php server
+      proxy: `https://${process.env.DEFAULT_DOMAIN}`,
+      open: false,
+      port: 1337,
+      ui: {
+        port: 1338,
+      },
+      notify: true,
+    });
+    // Watch sass files and compile them. Use polling because the Virtualbox
+    // shared folders implementation does not emit file system events from the
+    // host to the VM: https://github.com/floatdrop/gulp-watch/issues/213.
+    gulp.watch(src.scss, { usePolling: true }, gulp.series('sass'));
+    // Update the page automatically if php files change
+    gulp.watch(src.php, { usePolling: true }).on('change', reload);
+  })
 );
 
 // Give another name for serve


### PR DESCRIPTION
Uses `DEFAULT_DOMAIN` as the proxy address. Also sets `open` to `false`, to stop the web browser from automatically starting. 