### PR TITLE
Set third octet in the IP address to be static

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ site_config = YAML.load_file(config_file)
 private_ip_file = File.join(DIR,'.vagrant','private.ip')
 
 unless File.exists?(private_ip_file)
-  private_ip = "192.168.#{rand(255)}.#{rand(2..255)}"
+  private_ip = "192.168.250.#{rand(2..255)}"
   File.write(private_ip_file, private_ip)
 else
   private_ip = File.open(private_ip_file, 'rb') { |file| file.read }


### PR DESCRIPTION
This is to avoid setting the IP address in the same network as the default VirtualBox Host-only adapter. Also, this way vagrant doesn't create a new network adapter whenever the IP address resets.