### PR TITLE
Limit vCPUs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -145,16 +145,8 @@ Vagrant.configure('2') do |config|
   end
 
   config.vm.provider 'virtualbox' do |vb|
-    # Give VM access to all cpu cores on the host
-    cpus = case RbConfig::CONFIG['host_os']
-      when /darwin/ then `sysctl -n hw.physicalcpu`.to_i
-      when /linux/ then `nproc`.to_i
-      else 2
-    end
-
-    # Customize memory in MB
-    vb.customize ['modifyvm', :id, '--memory', 1536]
-    vb.customize ['modifyvm', :id, '--cpus', cpus]
+    vb.memory = 1536
+    vb.cpus = 2
 
     # Fix for slow external network connections
     vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']


### PR DESCRIPTION
Limits the vCPUs to 2.

Also make the Vagrantfile prettier by streamlining the virtualbox provider.