### PR TITLE
Set PHP 8.0 as the default

### DIFF
--- a/nginx/php.conf
+++ b/nginx/php.conf
@@ -2,4 +2,4 @@
 # Define PHP version in use
 # See: https://seravo.com/docs/configuration/php7-hhvm/
 ##
-set $mode php7.4;
+set $mode php8.0;


### PR DESCRIPTION
Makes sites deployed using this WordPress template use PHP 8.0 by default instead of 7.4 with ended active supported.