### PR TITLE
Improve composer details, security and performance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,49 @@
 {
   "name": "seravo/wordpress",
   "type": "project",
-  "license": "MIT",
+  "license": "GPL-3.0-or-later",
   "description": "Seravo WordPress project template",
   "homepage": "https://seravo.com/",
   "keywords": [
     "wordpress", "composer", "wp", "vagrant", "docker", "wp-palvelu", "seravo"
   ],
-  "config": {
-    "preferred-install": "dist",
-    "allow-plugins": {
-      "johnpbloch/wordpress-core-installer": true,
-      "koodimonni/composer-dropin-installer": true,
-      "composer/installers": true
-    }
-  },
-  "autoload": {
-    "psr-0": {"WordPress\\Installer": "scripts"}
-  },
-  "scripts": {
-    "post-install-cmd": [
-      "WordPress\\Installer::symlinkWPContent"
-    ],
-    "post-update-cmd": [
-      "WordPress\\Installer::symlinkWPContent"
-    ]
+  "support": {
+    "docs": "https://seravo.com/docs/",
+    "issues": "https://github.com/Seravo/wordpress/issues"
   },
   "repositories": [
     {
       "type": "composer",
-      "url": "https://wpackagist.org"
+      "url": "https://wpackagist.org",
+      "only": [
+        "wpackagist-plugin/*",
+        "wpackagist-theme/*"
+      ]
     },
     {
       "type": "composer",
-      "url": "https://wp-languages.github.io"
+      "url": "https://wp-languages.github.io",
+      "only": [
+        "koodimonni-language/*",
+        "koodimonni-plugin-language/*",
+        "koodimonni-theme-language/*"
+      ]
     }
   ],
   "require": {
     "php": ">=7.2",
+
+    "koodimonni/composer-dropin-installer": "^1.0",
     "johnpbloch/wordpress-core-installer": "^2.0",
     "johnpbloch/wordpress-core": "^6.0",
     "composer/installers": "^1.0",
-    "koodimonni/composer-dropin-installer": "^1.0",
-    "roots/bedrock-autoloader": "^1.0",
-    "vlucas/phpdotenv": "^5.0",
+    "composer/installers": "^1.0",
 
     "koodimonni-language/fi": "*",
     "koodimonni-language/sv_se": "*",
 
+    "vlucas/phpdotenv": "^5.0",
+    "roots/bedrock-autoloader": "^1.0",
     "seravo/seravo-plugin": "*",
 
     "wpackagist-plugin/google-site-kit": "*",
@@ -55,6 +51,16 @@
     "wpackagist-plugin/wp-recaptcha-integration": "*",
 
     "wpackagist-theme/twentynineteen": "*"
+  },
+  "config": {
+    "platform-check": false,
+    "preferred-install": "dist",
+    "optimize-autoloader": true,
+    "allow-plugins": {
+      "composer/installers": true,
+      "johnpbloch/wordpress-core-installer": true,
+      "koodimonni/composer-dropin-installer": true
+    }
   },
   "extra": {
     "installer-paths": {
@@ -69,5 +75,16 @@
       ".": ["type:seravo-wordpress-dropin"]
     },
     "wordpress-install-dir": "htdocs/wordpress"
+  },
+  "autoload": {
+    "psr-0": {"WordPress\\Installer": "scripts"}
+  },
+  "scripts": {
+    "post-install-cmd": [
+      "WordPress\\Installer::symlinkWPContent"
+    ],
+    "post-update-cmd": [
+      "WordPress\\Installer::symlinkWPContent"
+    ]
   }
 }


### PR DESCRIPTION
Makes the following changes to `composer.json`:

- Fix license to match the LICENSE file. License changed from MIT to GPLv3 in https://github.com/Seravo/wordpress/commit/68e404abfa7ab44231f3fb9e79e9f37b3da231ea.
- Add "support" links to GitHub and docs.seravo.com.
- Limit repository scopes to harden security.
- Disable platform checks for performance. It was useless as we don't want to prevent the site from working with PHP < 7.2.
- Optimize autoloader for performance. Non-optimized autoloader isn't meant for production use.