### PR TITLE
Temporarily lower composer stability requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
       "url": "https://wp-languages.github.io"
     }
   ],
+  "minimum-stability": "dev",
   "require": {
     "php": ">=7.2",
     "johnpbloch/wordpress-core-installer": "^2.0",


### PR DESCRIPTION
Temporarily set Composer minimum stability requirement to "dev" due to likely upstream versioning issue.