### PR TITLE
Revert defaulting to Vagrant beta box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# VAGRANTFILE 2022-02-21
+# VAGRANTFILE 2022-08-08
 
 require 'yaml'
 require 'mkmf'
@@ -69,10 +69,10 @@ Vagrant.configure('2') do |config|
   config.ssh.forward_agent = true
 
   # Minimum box version requirement for this Vagrantfile revision
-  config.vm.box_version = ">= 20220221.0.0"
+  config.vm.box_version = ">= 20220800.0.0"
 
   # Use precompiled box
-  config.vm.box = 'seravo/wordpress-beta'
+  config.vm.box = 'seravo/wordpress'
 
   # Use the name of the box as the hostname
   config.vm.hostname = site_config['name']


### PR DESCRIPTION
Beta box was set as the default in https://github.com/Seravo/wordpress/commit/25aaae3621704276297dadda9abc98f653e5f21c because the regular box hadn't been updated in years.

They have both been up-to-date for a while now so it's time to revert the change. Let's try to keep beta box only one version ahead from now on.

Will merge today unless there's any opposing comments. Doesn't need testing or review.