### PR TITLE
Bump wordpress-core to 6.0

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,6 +1,6 @@
 name: Acceptance tests
 
-on: [push, pull_request]
+on: [push]
 
 env:
   CONTAINER: wordpress
@@ -8,7 +8,7 @@ env:
 
 jobs:
   acceptance:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -21,4 +21,3 @@ jobs:
             --env WP_USER_UID=1001 \
             --env DEBUG=true \
             --rm "${{env.CI_IMAGE}}"
-

--- a/.github/workflows/gnitpick.yml
+++ b/.github/workflows/gnitpick.yml
@@ -1,11 +1,11 @@
 ---
-name: 'Nitpick git commits'
+name: "Nitpick git commits"
 
 on: [push, pull_request]
 
 env:
   DOMAINS: seravo.com
-  PYTHON_VERSION: 3.6
+  PYTHON_VERSION: "3.10"
 
 jobs:
   nitpick:
@@ -14,8 +14,8 @@ jobs:
       - name: Setup repository
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}           
-      
+          ref: ${{ github.head_ref }}
+
       - name: Install Gnitpick
         run: curl -O https://raw.githubusercontent.com/Seravo/gnitpick/master/gnitpick.py
 
@@ -26,4 +26,3 @@ jobs:
 
       - name: Run gnitpick
         run: python3 gnitpick.py --verbose --email-domains "${DOMAINS}"
-

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   "require": {
     "php": ">=7.2",
     "johnpbloch/wordpress-core-installer": "^2.0",
-    "johnpbloch/wordpress-core": "^5.0",
+    "johnpbloch/wordpress-core": "^6.0",
     "composer/installers": "^1.0",
     "koodimonni/composer-dropin-installer": "^1.0",
     "roots/bedrock-autoloader": "^1.0",


### PR DESCRIPTION
- Use newer Python version for Gnitpick
- Bump wordpress-core to 6.0