### PR TITLE
Set DEBUG=true always

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,8 @@ services:
     - wordpress:/data
     - .:/data/wordpress
     environment:
-    - WP_USER_UID=${WP_USER_UID:-1000}
-    - DEBUG=${DEBUG}
-    entrypoint: /sbin/swd_init
+    #- WP_USER_UID=${WP_USER_UID:-1000}
+    - DEBUG="true"
 
 volumes:
   wordpress:


### PR DESCRIPTION
This makes container output more verbose, thus helping when any issues occur during startup process.