### PR TITLE
Trigger workflow on PR

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,6 +1,6 @@
 name: Acceptance tests
 
-on: [push]
+on: [pull_request]
 
 env:
   CONTAINER: wordpress


### PR DESCRIPTION
This makes it easier to contribute to project using external forks, as now PRs are the events that trigger actions. This makes it possible to run our acceptance test suite even when third parties do contributions.

Related: #208