### PR TITLE
Drop default recaptcha plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
 
     "wpackagist-plugin/google-site-kit": "*",
     "wpackagist-plugin/two-factor": "*",
-    "wpackagist-plugin/wp-recaptcha-integration": "*",
 
     "wpackagist-theme/twentytwentythree": "*"
   },


### PR DESCRIPTION
Support status for plugin is now unclear, so it's better to drop it until we have better replacement.