### PR TITLE
Do not set default PHP version at project level

### DIFF
--- a/nginx/php.conf
+++ b/nginx/php.conf
@@ -2,4 +2,4 @@
 # Define PHP version in use
 # See: https://seravo.com/docs/configuration/php-versions/
 ##
-set $mode php8.2;
+#set $mode php8.3;


### PR DESCRIPTION
This makes project by default use Seravo's recommended/default PHP version, which is chosen based on the WordPress core support status.

Impact: major